### PR TITLE
Fix orchestrator initialization when crewAI missing

### DIFF
--- a/inv_agent/agents.py
+++ b/inv_agent/agents.py
@@ -6,7 +6,14 @@ from typing import Any, Dict, List, Optional
 try:
     from crewai import Agent
 except ImportError:  # pragma: no cover - library not installed
-    Agent = object  # type: ignore
+    class Agent:  # type: ignore
+        """Fallback agent used when crewAI is unavailable."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+            """Initialize a dummy agent that ignores all parameters."""
+
+        def run(self, prompt: str) -> str:
+            return "[crewAI not installed]"
 
 
 def create_analysis_agent(name: str, description: str) -> Agent:

--- a/inv_agent/orchestrator.py
+++ b/inv_agent/orchestrator.py
@@ -15,7 +15,11 @@ class Orchestrator:
     def __init__(self):
         self.agents = build_agents()
         self.memory = MemoryManager()
-        self.crew = Crew(agents=list(self.agents.values()))  # type: ignore
+        if Crew is object:
+            # crewAI isn't installed; skip crew creation to avoid TypeError
+            self.crew = None
+        else:
+            self.crew = Crew(agents=list(self.agents.values()))  # type: ignore
 
     def route_request(self, asset: str, brief: str) -> str:
         """Send the daily brief to the appropriate agent and return the response."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the package root is on the path when running via pytest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from inv_agent.orchestrator import Orchestrator
+
+
+def test_orchestrator_initializes_without_crewai():
+    # Ensure crewai is really not available for this test
+    crewai = importlib.util.find_spec("crewai")
+    assert crewai is None
+    orch = Orchestrator()
+    assert orch.crew is None


### PR DESCRIPTION
## Summary
- add dummy Agent implementation used when crewAI isn't installed
- handle absence of crewAI in `Orchestrator.__init__`
- add regression test for orchestrator startup without crewAI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712724d70c832f91f5ac49abc7ded2