### PR TITLE
Isolate memory path in orchestrator test

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -7,12 +7,25 @@ import pytest
 # Ensure the package root is on the path when running via pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from inv_agent.orchestrator import Orchestrator
+from inv_agent import orchestrator, memory
 
 
-def test_orchestrator_initializes_without_crewai():
-    # Ensure crewai is really not available for this test
-    crewai = importlib.util.find_spec("crewai")
-    assert crewai is None
-    orch = Orchestrator()
+def test_orchestrator_initializes_without_crewai(tmp_path, monkeypatch):
+    """Orchestrator should initialize even when crewai is missing.
+
+    The MemoryManager writes to disk on initialization, so patch it to use the
+    pytest-provided ``tmp_path`` to avoid polluting the repository.
+    """
+
+    # Pretend ``crewai`` is not installed regardless of the test environment
+    monkeypatch.setattr(orchestrator, "Crew", object)
+
+    original_init = memory.MemoryManager.__init__
+
+    def patched_init(self, base_dir="memory"):
+        original_init(self, base_dir=tmp_path)
+
+    monkeypatch.setattr(memory.MemoryManager, "__init__", patched_init)
+
+    orch = orchestrator.Orchestrator()
     assert orch.crew is None


### PR DESCRIPTION
## Summary
- patch orchestrator test to use a temporary directory for MemoryManager
- mock CrewAI so tests work even if crewai is installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873740f57c8832fb49f409e11f2cc97