### PR TITLE
Add memory tests for route_request

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 from pathlib import Path
 
@@ -8,11 +7,32 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from inv_agent.orchestrator import Orchestrator
+from inv_agent.memory import MemoryManager
+import json
 
 
-def test_orchestrator_initializes_without_crewai():
-    # Ensure crewai is really not available for this test
-    crewai = importlib.util.find_spec("crewai")
-    assert crewai is None
+def test_orchestrator_initializes_without_crewai(monkeypatch):
+    """Orchestrator should skip crew creation when CrewAI is patched out."""
+    monkeypatch.setattr("inv_agent.orchestrator.Crew", object)
     orch = Orchestrator()
     assert orch.crew is None
+
+
+def test_route_request_appends_history(monkeypatch, tmp_path):
+    """route_request should write the brief to memory and return placeholder."""
+    monkeypatch.setattr("inv_agent.orchestrator.Crew", object)
+    orch = Orchestrator()
+    orch.memory = MemoryManager(base_dir=tmp_path)
+
+    asset = "gold"
+    brief = "Sample brief for testing"
+    response = orch.route_request(asset, brief)
+
+    assert response == "[crewAI not installed]"
+
+    file_path = orch.memory._file_for_asset(asset)
+    assert file_path.exists()
+    with file_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data == [brief]
+    assert orch.memory.get_history(asset) == [brief]


### PR DESCRIPTION
## Summary
- add regression tests for Orchestrator memory handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687373fab950832f96ec07f542972c0a