### PR TITLE
Add generate report feature using Serper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project implements a proof-of-concept multi-agent investment advisor using 
 - An orchestrator that routes daily briefs to the relevant agent and stores the history of briefs.
 - A Python coder agent is included for future automation tasks.
 - Enhanced Gradio interface with improved layout and theming.
+- Generate consolidated reports using Serper research across all assets.
 
 ## Running
 

--- a/inv_agent/frontend.py
+++ b/inv_agent/frontend.py
@@ -12,6 +12,10 @@ def handle_chat(asset: str, brief: str) -> str:
     return orchestrator.route_request(asset, brief)
 
 
+def handle_report() -> str:
+    return orchestrator.generate_report()
+
+
 def main() -> None:
     assets = list(orchestrator.agents.keys())
     assets.remove("python_coder")
@@ -34,9 +38,11 @@ def main() -> None:
 
         with gr.Row():
             submit = gr.Button("Submit")
+            report = gr.Button("Generate Report")
             clear = gr.Button("Clear")
 
         submit.click(handle_chat, inputs=[asset, brief], outputs=output)
+        report.click(handle_report, None, output)
         clear.click(lambda: "", None, output)
 
     demo.launch()

--- a/inv_agent/orchestrator.py
+++ b/inv_agent/orchestrator.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+import requests
+
 from dotenv import load_dotenv
 import os
 
@@ -50,3 +52,43 @@ class Orchestrator:
             response = "[crewAI not installed]"
         self.memory.append_entry(asset, brief)
         return response
+
+    def generate_report(self) -> str:
+        """Compile analysis from all agents using Serper search results."""
+        if not SERPER_API_KEY:
+            return "[Serper API key not configured]"
+
+        sections: List[str] = []
+        for name, agent in self.agents.items():
+            if name == "python_coder":
+                continue
+            try:
+                resp = requests.post(
+                    "https://google.serper.dev/news",
+                    headers={"X-API-KEY": SERPER_API_KEY},
+                    json={"q": name, "num": 3},
+                    timeout=10,
+                )
+                data = resp.json()
+                snippets = []
+                for item in data.get("news", []):
+                    title = item.get("title", "")
+                    link = item.get("link", "")
+                    snippets.append(f"{title} - {link}")
+                research = " ".join(snippets) if snippets else "No results"
+            except Exception:
+                research = "[search failed]"
+
+            history = self.memory.get_history(name)
+            prompt = (
+                f"Research findings: {research}. "
+                f"Historical briefs: {history}. "
+                f"Provide your investment view on {name}."
+            )
+            try:
+                result = agent.run(prompt)  # type: ignore[attr-defined]
+            except AttributeError:
+                result = "[crewAI not installed]"
+            sections.append(f"## {name}\n{result}")
+
+        return "\n\n".join(sections)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ crewai
 gradio
 
 python-dotenv
+requests

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -16,3 +16,19 @@ def test_orchestrator_initializes_without_crewai(monkeypatch):
     from inv_agent.orchestrator import Orchestrator
     orch = Orchestrator()
     assert orch.crew is None
+
+
+def test_generate_report(monkeypatch):
+    """generate_report should return a string even if requests fail."""
+    from inv_agent.orchestrator import Orchestrator
+
+    orch = Orchestrator()
+
+    class DummyResp:
+        def json(self):
+            return {}
+
+    monkeypatch.setattr("requests.post", lambda *a, **k: DummyResp())
+
+    report = orch.generate_report()
+    assert isinstance(report, str)


### PR DESCRIPTION
## Summary
- integrate `requests` and implement Serper-based research in orchestrator
- add Generate Report button in Gradio UI
- update README with new feature
- update requirements with `requests`
- test new method `generate_report`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737c12ff0c832fa1a41a58698d1955