### PR TITLE
Configure agents to use gpt‑4o‑mini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 OPENAI_API_KEY=your-openai-key-here
-OPENAI_MODEL_NAME=gpt-4o
+OPENAI_MODEL_NAME=gpt-4o-mini
 GROQ_API_KEY=your-groq-key-here
 SERPER_API_KEY=your-serper-key-here

--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@ This project implements a proof-of-concept multi-agent investment advisor using 
    python -m inv_agent.frontend
    ```
 
+### Model configuration
+
+All agents default to OpenAI's `gpt-4o-mini` model. You can override this by
+setting the `OPENAI_MODEL_NAME` environment variable in your `.env` file.
+
 CrewAI is required for the agents to function. If it is not installed, placeholder messages will be returned.

--- a/inv_agent/agents.py
+++ b/inv_agent/agents.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
+import os
+
+MODEL_NAME = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
 
 try:
     from crewai import Agent
 except ImportError:  # pragma: no cover - library not installed
+
     class Agent:  # type: ignore
         """Fallback agent used when crewAI is unavailable."""
 
@@ -24,6 +28,7 @@ def create_analysis_agent(name: str, description: str) -> Agent:
         backstory=description,
         allow_delegation=False,
         verbose=True,
+        llm=MODEL_NAME,
     )
 
 
@@ -35,6 +40,7 @@ def create_python_coder_agent() -> Agent:
         backstory="An expert Python developer helping with tools and front end.",
         allow_delegation=False,
         verbose=True,
+        llm=MODEL_NAME,
     )
 
 
@@ -48,6 +54,8 @@ def build_agents() -> Dict[str, Agent]:
         "chip manufacturing": "Expert in public chip manufacturing companies.",
         "ai companies": "Expert in public AI company performance.",
     }
-    agents = {name: create_analysis_agent(name, desc) for name, desc in descriptions.items()}
+    agents = {
+        name: create_analysis_agent(name, desc) for name, desc in descriptions.items()
+    }
     agents["python_coder"] = create_python_coder_agent()
     return agents

--- a/inv_agent/memory.py
+++ b/inv_agent/memory.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import List
 
+
 class MemoryManager:
     def __init__(self, base_dir: str = "memory"):
         self.base_path = Path(base_dir)

--- a/inv_agent/orchestrator.py
+++ b/inv_agent/orchestrator.py
@@ -8,7 +8,6 @@ import os
 load_dotenv()
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_MODEL_NAME = os.getenv("OPENAI_MODEL_NAME")
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 SERPER_API_KEY = os.getenv("SERPER_API_KEY")
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -14,5 +14,6 @@ def test_orchestrator_initializes_without_crewai(monkeypatch):
         pytest.skip("crewai is installed")
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
     from inv_agent.orchestrator import Orchestrator
+
     orch = Orchestrator()
     assert orch.crew is None


### PR DESCRIPTION
## Summary
- default model is now `gpt-4o-mini`
- document the model choice in README
- update example env file with the new model
- pass model into CrewAI agents
- minor formatting with black

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737bd92534832f927866e304cba423